### PR TITLE
Clang warning fix about overloaded virtual methods

### DIFF
--- a/include/recpp/rx/Completable.h
+++ b/include/recpp/rx/Completable.h
@@ -219,6 +219,8 @@ namespace recpp::rx
 		Completable delay(async::Scheduler &scheduler, const std::chrono::duration<Rep, Period> &delay, bool delayError);
 
 	protected:
+		using rscpp::Publisher<int>::subscribe;
+
 		/**
 		 * @brief Construct a new {@link Completable} instance with the given private implementation.
 		 *

--- a/include/recpp/rx/Maybe.h
+++ b/include/recpp/rx/Maybe.h
@@ -238,6 +238,8 @@ namespace recpp::rx
 		Maybe<T> switchIfEmpty(const T &defaultValue);
 
 	protected:
+		using rscpp::Publisher<T>::subscribe;
+
 		/**
 		 * @brief Construct a new {@link Maybe} instance with the given private implementation.
 		 *

--- a/include/recpp/rx/Observable.h
+++ b/include/recpp/rx/Observable.h
@@ -409,6 +409,8 @@ namespace recpp::rx
 		Maybe<T> last();
 
 	protected:
+		using rscpp::Publisher<T>::subscribe;
+		
 		/**
 		 * @brief Construct a new {@link Observable} instance with the given private implementation.
 		 *

--- a/include/recpp/rx/Observable.h
+++ b/include/recpp/rx/Observable.h
@@ -410,7 +410,7 @@ namespace recpp::rx
 
 	protected:
 		using rscpp::Publisher<T>::subscribe;
-		
+
 		/**
 		 * @brief Construct a new {@link Observable} instance with the given private implementation.
 		 *

--- a/include/recpp/rx/Single.h
+++ b/include/recpp/rx/Single.h
@@ -248,6 +248,8 @@ namespace recpp::rx
 		Single<T> delay(async::Scheduler &scheduler, const std::chrono::duration<Rep, Period> &delay, bool delayError);
 
 	protected:
+		using rscpp::Publisher<T>::subscribe;
+
 		/**
 		 * @brief Construct a new {@link Single} instance with the given private implementation.
 		 *


### PR DESCRIPTION
Clang warning fix about overloaded virtual methods